### PR TITLE
Feature lease monitor

### DIFF
--- a/source/DHCPMgrUtils/Makefile.am
+++ b/source/DHCPMgrUtils/Makefile.am
@@ -29,6 +29,6 @@ libCcspDhcpMgrUtils_la_CPPFLAGS = -I$(top_srcdir)/source/DHCPMgrUtils/include \
                                   -I$(top_srcdir)/source/TR-181/middle_layer_src \
                                   -I$(top_srcdir)/source/DHCPServerUtils/utils/include 
 
-libCcspDhcpMgrUtils_la_SOURCES = cosa_common_util.c helpers.c dhcpmgr_controller.c
+libCcspDhcpMgrUtils_la_SOURCES = cosa_common_util.c helpers.c dhcpmgr_controller.c dhcp_lease_monitor_thrd.c
 
 libCcspDhcpMgrUtils_la_LIBADD = -lccsp_common -ltelemetry_msgsender -lulog -lsyscfg -lsysevent -ltime_conversion -lprint_uptime

--- a/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.c
+++ b/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.c
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 #include <string.h>
 #include <strings.h>
 #include <sys/types.h>

--- a/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.c
+++ b/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.c
@@ -1,0 +1,117 @@
+#include <string.h>
+#include <strings.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <netinet/if_ether.h>
+#include <net/if_arp.h>
+#include <sys/stat.h>
+#include <sys/file.h>
+#include <fcntl.h>
+#include "secure_wrapper.h"
+#include "ansc_platform.h"
+#include "util.h"
+#include "cosa_dhcpv4_apis.h"
+#include "dhcpv4_interface.h"
+#include "dhcpmgr_controller.h"
+#include "dhcp_lease_monitor_thrd.h"
+
+static int ipcListenFd = 0;
+
+static ANSC_STATUS DhcpMgr_LeaseMonitor_Init();
+static void* DhcpMgr_LeaseMonitor_Thrd(void *arg);
+
+static ANSC_STATUS DhcpMgr_LeaseMonitor_Init()
+{
+    if ((ipcListenFd = nn_socket(AF_SP, NN_PULL)) < 0)
+    {
+        DHCPMGR_LOG_ERROR("[%s-%d] Failed to create IPC socket\n", __FUNCTION__, __LINE__);
+        return ANSC_STATUS_FAILURE;
+    }
+    if ((nn_bind(ipcListenFd, DHCP_MANAGER_ADDR)) < 0)
+    {
+        DHCPMGR_LOG_ERROR("[%s-%d] Failed to bind IPC socket\n", __FUNCTION__, __LINE__);
+        nn_close(ipcListenFd);
+        return ANSC_STATUS_FAILURE;
+    }
+    DHCPMGR_LOG_INFO("[%s-%d] IPC Socket initialized and bound successfully\n", __FUNCTION__, __LINE__);
+    return ANSC_STATUS_SUCCESS;
+}
+
+ANSC_STATUS DhcpMgr_LeaseMonitor_Start()
+{
+    pthread_t ipcThreadId;
+    ANSC_STATUS retStatus = ANSC_STATUS_FAILURE;
+    int ret = -1;
+
+    if(DhcpMgr_LeaseMonitor_Init() != ANSC_STATUS_SUCCESS)
+    {
+        DHCPMGR_LOG_ERROR("[%s-%d] Failed to initialise IPC messaging\n", __FUNCTION__, __LINE__);
+        return ANSC_STATUS_FAILURE;
+    }
+
+    ret = pthread_create(&ipcThreadId, NULL, &DhcpMgr_LeaseMonitor_Thrd, NULL);
+    if (0 != ret)
+    {
+        DHCPMGR_LOG_ERROR("[%s-%d] Failed to start IPC Thread Error:%d\n", __FUNCTION__, __LINE__, ret);
+    }
+    else
+    {
+        DHCPMGR_LOG_INFO("[%s-%d] IPC Thread Started Successfully\n", __FUNCTION__, __LINE__);
+        retStatus = ANSC_STATUS_SUCCESS;
+    }
+    return retStatus;
+}
+
+static void* DhcpMgr_LeaseMonitor_Thrd(void *arg)
+{
+    (void)arg;  // Mark argument as intentionally unused
+    pthread_detach(pthread_self());
+
+    BOOL bRunning = TRUE;
+
+    int bytes = 0;
+    int msg_size = sizeof(PLUGIN_MSG);
+    PLUGIN_MSG plugin_msg;
+    memset(&plugin_msg, 0, sizeof(PLUGIN_MSG));
+
+    DHCPMGR_LOG_INFO("[%s-%d] DHCP Lease Monitor Thread Started\n", __FUNCTION__, __LINE__);
+
+    while (bRunning)
+    {
+        bytes = nn_recv(ipcListenFd, (PLUGIN_MSG *)&plugin_msg, msg_size, 0);
+        if (bytes == msg_size)
+        {
+            DHCPMGR_LOG_INFO("[%s-%d] Received valid message of size %d\n", __FUNCTION__, __LINE__, bytes);
+            switch (plugin_msg.version)
+            {
+                case DHCP_VERSION_4:
+                    DHCPMGR_LOG_INFO("[%s-%d] Processing DHCPv4 lease for interface: %s\n",__FUNCTION__, __LINE__, plugin_msg.ifname);
+                    DHCPMgr_AddDhcpv4Lease(plugin_msg.ifname, &plugin_msg.data.dhcpv4);
+                    break;
+                case DHCP_VERSION_6:
+                    //TO-DO:Update the lease details of v6
+                    break;
+                default:
+                    DHCPMGR_LOG_ERROR("[%s-%d] Invalid Message version sent to DhcpManager\n", __FUNCTION__, __LINE__);
+                    break;
+            }
+            memset(&plugin_msg, 0, sizeof(PLUGIN_MSG));
+        }
+        else if (bytes < 0)
+        {
+            DHCPMGR_LOG_ERROR("[%s-%d] Failed to receive message from IPC\n", __FUNCTION__, __LINE__);
+        }
+        else
+        {
+            DHCPMGR_LOG_ERROR("[%s-%d] message size unexpected\n", __FUNCTION__, __LINE__);
+        }
+    }
+    nn_shutdown(ipcListenFd, 0);
+    nn_close(ipcListenFd);
+    DHCPMGR_LOG_INFO("[%s-%d] DHCP Lease Monitor Thread Exiting\n", __FUNCTION__, __LINE__);
+    pthread_exit(NULL);
+}

--- a/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.h
+++ b/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.h
@@ -1,0 +1,90 @@
+#include <stdbool.h>
+#include <nanomsg/nn.h>
+#include <nanomsg/pipeline.h>
+
+#define DHCP_MANAGER_ADDR              "tcp://127.0.0.1:50324"
+
+#define BUFLEN_32                        32          //buffer length 32
+#define BUFLEN_64                        64          //buffer length 64
+#define BUFLEN_48                        48          //buffer length 48
+#define BUFLEN_128                       128         //buffer length 128
+#define BUFLEN_256                       256         //buffer length 256
+#define AFTR_NAME_LENGTH                 256
+
+typedef struct _DHCPv6_PLUGIN_MSG
+{
+    bool isExpired;        /** Is the lease time expired ? */
+    char ifname[BUFLEN_32];    /** Dhcp interface name */
+
+    //address details
+    struct {
+        char     address[BUFLEN_48];      /**< New IPv6 address */
+        uint32_t IA_ID;
+        uint32_t PreferedLifeTime;
+        uint32_t ValidLifeTime;
+        uint32_t T1;
+        uint32_t T2;
+    }ia_na;
+
+    //IAPD details
+    struct {
+        char     Prefix[BUFLEN_48];   /**< New site prefix, if prefixAssigned==TRUE */
+        uint32_t PrefixLength;
+        uint32_t IA_ID;
+        uint32_t PreferedLifeTime;
+        uint32_t ValidLifeTime;
+        uint32_t T1;
+        uint32_t T2;
+    }ia_pd;
+
+    //DNS details
+    struct {
+        bool assigned;
+        char nameserver[BUFLEN_128];  /**< New nameserver,   */
+        char nameserver1[BUFLEN_128];  /**< New nameserver,   */
+    } dns;
+
+    //MAPT
+    struct {
+        bool Assigned;     /**< Have we been assigned mapt config ? */
+        unsigned char  Container[BUFLEN_256]; /* MAP-T option 95 in hex format*/
+    }mapt;
+ 
+    #if 0
+    //TODO: MAPE support not added yet
+    struct {
+        bool Assigned;     /**< Have we been assigned mape config ? */
+        unsigned char  Container[BUFLEN_256]; /* MAP-E option 94 in hex format*/
+    }mape;
+    #endif
+
+    char domainName[BUFLEN_64];  /**< New domain Name,   */
+    char ntpserver[BUFLEN_128];  /**< New ntp server(s), dhcp server may provide this */
+    char aftr[AFTR_NAME_LENGTH];      /**< dhcp server may provide this */
+
+}DHCPv6_PLUGIN_MSG;
+
+typedef enum {
+    DHCP_VERSION_4,
+    DHCP_VERSION_6,
+} DHCP_SOURCE;
+
+typedef struct {
+    char ifname[BUFLEN_32];
+    DHCP_SOURCE version;
+    union {
+        DHCPv4_PLUGIN_MSG dhcpv4;
+        DHCPv6_PLUGIN_MSG dhcpv6;
+    } data;
+} PLUGIN_MSG;
+
+/**
+ * @brief Starts the DHCP Lease Monitor service.
+ *
+ * This function initializes and starts the DHCP Lease Monitor,
+ * which listens for DHCP lease events and processes lease updates.
+ *
+ * @return ANSC_STATUS_SUCCESS on successful start, ANSC_STATUS_FAILURE otherwise.
+ */
+ANSC_STATUS DhcpMgr_LeaseMonitor_Start();
+

--- a/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.h
+++ b/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.h
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 #include <stdbool.h>
 #include <nanomsg/nn.h>
 #include <nanomsg/pipeline.h>

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -30,7 +30,7 @@
 #include "cosa_dhcpv4_dml.h"
 #include "dhcpv4_interface.h"
 #include "dhcpmgr_controller.h"
-
+#include "dhcp_lease_monitor_thrd.h"
 #include "dhcp_client_common_utils.h"
 
 
@@ -130,6 +130,12 @@ static void* DhcpMgr_MainController( void *args )
     BOOL bRunning = TRUE;
     struct timeval tv;
     int n = 0;
+
+    ANSC_STATUS retStatus = DhcpMgr_LeaseMonitor_Start();
+    if(retStatus != ANSC_STATUS_SUCCESS)
+    {
+        DHCPMGR_LOG_INFO("%s %d - Lease Monitor Thread failed to start!\n", __FUNCTION__, __LINE__ );
+    }
 
     while (bRunning)
     {

--- a/source/TR-181/board_sbapi/cosa_dhcpv4_apis.c
+++ b/source/TR-181/board_sbapi/cosa_dhcpv4_apis.c
@@ -84,7 +84,7 @@
 #include "util.h"
 #include "dhcp_client_common_utils.h"
 #include "cosa_dhcpv4_internal.h"
-#include "ipc_msg.h"
+//#include "ipc_msg.h"
 #include "cosa_dhcpv4_dml.h"
 
 #if ( defined _COSA_SIM_ )
@@ -144,7 +144,7 @@
 
 #define BOOTSTRAP_INFO_FILE             "/nvram/bootstrap.json"
 
-static int   ipcListenFd;
+//static int   ipcListenFd;
 COSA_DML_DHCPC_FULL     CH_g_dhcpv4_client[COSA_DML_DHCP_MAX_ENTRIES];
 COSA_DML_DHCP_OPT       g_dhcpv4_client_sent[COSA_DML_DHCP_MAX_ENTRIES][COSA_DML_DHCP_MAX_OPT_ENTRIES];
 COSA_DML_DHCPC_REQ_OPT  g_dhcpv4_client_req[COSA_DML_DHCP_MAX_ENTRIES][COSA_DML_DHCP_MAX_OPT_ENTRIES];
@@ -1396,7 +1396,7 @@ CosaDmlDhcpInit
     //pthread_create(&pid, NULL, usg_get_cpe_associated_ssid, NULL);
     return ANSC_STATUS_SUCCESS;
 }
-
+#if 0
 static ANSC_STATUS IpcServerInit()
 {
     //int i;
@@ -1566,7 +1566,7 @@ ANSC_STATUS DhcpMgr_StartIpcServer()
     }
     return retStatus ;
 }
-
+#endif
 /*
     Description:
         The API retrieves the Request option entry from Client table by index.

--- a/source/TR-181/middle_layer_src/cosa_dhcpv4_internal.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv4_internal.c
@@ -752,11 +752,13 @@ CosaDhcpv4BackendGetDhcpv4Info
             }
         }
     }
+#if 0
     ANSC_STATUS retStatus = DhcpMgr_StartIpcServer();
     if(retStatus != ANSC_STATUS_SUCCESS)
     {
         DHCPMGR_LOG_INFO("%s %d - IPC Thread failed to start!\n", __FUNCTION__, __LINE__ );
     }
+#endif
     /*****************************************
 
                 Get DHCPv4.Server.Pool.{i}

--- a/source/TR-181/middle_layer_src/cosa_dhcpv4_internal.h
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv4_internal.h
@@ -292,11 +292,13 @@ COSA_DATAMODEL_DHCPV4,  *PCOSA_DATAMODEL_DHCPV4;
     Function declaration
 */
 
+#if 0
 ANSC_STATUS
 DhcpMgr_StartIpcServer
     (
         VOID
     );
+#endif
 
 ANSC_HANDLE
 CosaDhcpv4Create


### PR DESCRIPTION
- Implement a pthread to create a TCP server socket that listens for DHCP lease messages from the DHCPv4/v6 plugins.
- Cleanup the existing static void* IpcServerThread( void *arg ) implementation from the DHCP Manager.