### PR TITLE
RDKBNETWOR-42: [DHCPv6] Implement Dibbler-client Plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -257,7 +257,8 @@ AC_CONFIG_FILES(
         source/DHCPClientUtils/DHCPv4Client/service_udhcpc/Makefile
         source/DHCPClientUtils/DHCPv4Client/dhcpmgr_udhcpc_plugin/Makefile
         source/DHCPClientUtils/DHCPv6Client/Makefile
-        source/DHCPMgrUtils/Makefile
+        source/DHCPClientUtils/DHCPv6Client/dhcpmgr_dibbler_plugin/Makefile
+	source/DHCPMgrUtils/Makefile
         source/IPv6rtmon/Makefile
         source/TR-181/board_sbapi/Makefile
         source/TR-181/middle_layer_src/Makefile

--- a/source/DHCPClientUtils/DHCPv6Client/Makefile.am
+++ b/source/DHCPClientUtils/DHCPv6Client/Makefile.am
@@ -16,6 +16,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ##########################################################################
 
+SUBDIRS = dhcpmgr_dibbler_plugin
+
 AM_CFLAGS = -fno-exceptions -Wall -Wextra
 AM_LDFLAGS = -lhal_platform -lz -lpthread -lccsp_common $(DBUS_LIBS)
 

--- a/source/DHCPClientUtils/DHCPv6Client/dhcpmgr_dibbler_plugin/Makefile.am
+++ b/source/DHCPClientUtils/DHCPv6Client/dhcpmgr_dibbler_plugin/Makefile.am
@@ -1,0 +1,31 @@
+##########################################################################
+# If not stated otherwise in this file or this component's LICENSE
+# file the following copyright and licenses apply:
+#
+# Copyright 2020 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+AM_LDFLAGS = -lz -lnanomsg
+
+bin_PROGRAMS = dhcpmgr_dibbler_plugin
+
+dhcpmgr_dibbler_plugin_CPPFLAGS = -I$(top_srcdir)/source/DHCPMgrUtils \
+                                  -I$(top_srcdir)/source/DHCPClientUtils/DHCPv4Client/ \
+                                  -I$(top_srcdir)/source/DHCPClientUtils/DHCPv4Client/include \
+                                  -I$(top_srcdir)/source/DHCPClientUtils/DHCPv6Client/include \
+                                  -I$(top_srcdir)/source/DHCPServerUtils/utils/include/ \
+                                  -I$(top_srcdir)/source/DHCPClientUtils/DHCPv6Client
+
+dhcpmgr_dibbler_plugin_SOURCES = dhcpmgr_dibbler_plugin.c

--- a/source/DHCPClientUtils/DHCPv6Client/dhcpmgr_dibbler_plugin/dhcpmgr_dibbler_plugin.c
+++ b/source/DHCPClientUtils/DHCPv6Client/dhcpmgr_dibbler_plugin/dhcpmgr_dibbler_plugin.c
@@ -1,0 +1,353 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include "util.h"
+#include "dhcp_lease_monitor_thrd.h"
+
+#define MAX_SEND_THRESHOLD                   5
+
+#define DHCPv6_INTERFACE_NAME                "IFACE"
+#define DHCPv6_IANA_ADDRESS                  "ADDR1"
+#define DHCPv6_IANA_IAID                     "ADDR1IAID"
+#define DHCPv6_IANA_PREF_LIFETIME            "ADDR1PREF"
+#define DHCPv6_IANA_VALID_LIFETIME           "ADDR1VALID"
+#define DHCPv6_IANA_T1                       "ADDR1T1"
+#define DHCPv6_IANA_T2                       "ADDR1T2"
+#define DHCPv6_IAPD_PREFIX                   "PREFIX1"
+#define DHCPv6_IAPD_PREFIXLEN                "PREFIX1LEN"
+#define DHCPv6_IAPD_IAID                     "PREFIX1IAID"
+#define DHCPv6_IAPD_PREF_LIFETIME            "PREFIX1PREF"
+#define DHCPv6_IAPD_VALID_LIFETIME           "PREFIX1VALID"
+#define DHCPv6_IAPD_T1                       "PREFIX1T1"
+#define DHCPv6_IAPD_T2                       "PREFIX1T2"
+//TO-DO: Parse SRV_OPTION17 (Vendor-Specific Options)
+#define DHCPv6_OPTION_DNS                    "SRV_OPTION23"
+#define DHCPv6_OPTION_DOMAIN                 "SRV_OPTION24"
+#define DHCPv6_OPTION_NTP                    "SRV_OPTION31"
+#define DHCPv6_OPTION_DSLITE                 "SRV_OPTION64"
+#define DHCPv6_OPTION_MAPT                   "SRV_OPTION95"
+
+#if 0  // Uncomment the following code to enable plugin logs
+
+#define PLUGIN_DBG_PRINT(fmt ...)     {\
+    FILE     *fp        = NULL;\
+    fp = fopen ( "/rdklogs/logs/DHCPMGRLog.txt.0", "a+");\
+    if (fp)\
+    {\
+        fprintf(fp,fmt);\
+        fclose(fp);\
+    }\
+}\
+
+#undef DHCPMGR_LOG_INFO
+#undef DHCPMGR_LOG_ERROR
+#undef DHCPMGR_LOG_DEBUG
+#undef DHCPMGR_LOG_WARNING
+#define DHCPMGR_LOG_INFO(fmt, ...)     PLUGIN_DBG_PRINT(fmt, ##__VA_ARGS__)
+#define DHCPMGR_LOG_ERROR(fmt, ...)    PLUGIN_DBG_PRINT(fmt, ##__VA_ARGS__)
+#define DHCPMGR_LOG_DEBUG(fmt, ...)    PLUGIN_DBG_PRINT(fmt, ##__VA_ARGS__)
+#define DHCPMGR_LOG_WARNING(fmt, ...)  PLUGIN_DBG_PRINT(fmt, ##__VA_ARGS__)
+#endif
+
+static int get_and_fill_env_data_dhcp6(DHCPv6_PLUGIN_MSG *dhcpv6_data, char *input_option)
+{
+    char *env;
+
+    if (dhcpv6_data == NULL || input_option == NULL)
+    {
+        DHCPMGR_LOG_INFO("[%s-%d] Invalid argument", __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    /** Interface name */
+    if ((env = getenv(DHCPv6_INTERFACE_NAME)) != NULL)
+    {
+        strncpy(dhcpv6_data->ifname, env, sizeof(dhcpv6_data->ifname));
+    }
+    else
+    {
+        DHCPMGR_LOG_ERROR("[%s-%d] Interface name is missing\n", __FUNCTION__, __LINE__);
+    }
+
+    /** DHCP Lease state */
+    if (strcmp(input_option, "add") == 0)
+    {
+        dhcpv6_data->isExpired = false;
+    }
+    else if (strcmp(input_option, "del") == 0)
+    {
+        dhcpv6_data->isExpired = true;
+    }
+    else
+    {
+        DHCPMGR_LOG_ERROR("[%s-%d] Unknown DHCPv6 state: %s\n", __FUNCTION__, __LINE__, input_option);
+    }
+    
+    /** IA_NA (Non-temporary address) */
+    if ((env = getenv(DHCPv6_IANA_ADDRESS)) != NULL)
+    {
+        strncpy(dhcpv6_data->ia_na.address, env, sizeof(dhcpv6_data->ia_na.address));
+        dhcpv6_data->ia_na.assigned = true;
+    }
+
+    if ((env = getenv(DHCPv6_IANA_IAID)) != NULL)
+    {
+        dhcpv6_data->ia_na.IA_ID = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IANA_PREF_LIFETIME)) != NULL)
+    {
+        dhcpv6_data->ia_na.PreferedLifeTime = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IANA_VALID_LIFETIME)) != NULL)
+    {
+        dhcpv6_data->ia_na.ValidLifeTime = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IANA_T1)) != NULL)
+    {
+        dhcpv6_data->ia_na.T1 = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IANA_T2)) != NULL)
+    {
+        dhcpv6_data->ia_na.T2 = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    /** IA_PD (Prefix delegation) */
+    if ((env = getenv(DHCPv6_IAPD_PREFIX)) != NULL)
+    {
+        strncpy(dhcpv6_data->ia_pd.Prefix, env, sizeof(dhcpv6_data->ia_pd.Prefix));
+        dhcpv6_data->ia_pd.assigned = true;
+    }
+
+    if ((env = getenv(DHCPv6_IAPD_PREFIXLEN)) != NULL)
+    {
+        dhcpv6_data->ia_pd.PrefixLength = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IAPD_IAID)) != NULL)
+    {
+        dhcpv6_data->ia_pd.IA_ID = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IAPD_PREF_LIFETIME)) != NULL)
+    {
+        dhcpv6_data->ia_pd.PreferedLifeTime = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IAPD_VALID_LIFETIME)) != NULL)
+    {
+        dhcpv6_data->ia_pd.ValidLifeTime = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IAPD_T1)) != NULL)
+    {
+        dhcpv6_data->ia_pd.T1 = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    if ((env = getenv(DHCPv6_IAPD_T2)) != NULL)
+    {
+        dhcpv6_data->ia_pd.T2 = (uint32_t) strtol(env, NULL, 10);
+    }
+
+    /** DNS servers */
+    if ((env = getenv(DHCPv6_OPTION_DNS)) != NULL)
+    {
+        char dns[256];
+        char *tok = NULL, *saveptr = NULL;
+        snprintf(dns, sizeof(dns), "%s", env);
+
+        tok = strtok_r(dns, " ", &saveptr);
+        if (tok)
+        {
+            strncpy(dhcpv6_data->dns.nameserver, tok, (sizeof(dhcpv6_data->dns.nameserver)-1));
+        }
+
+        tok = strtok_r(NULL, " ", &saveptr);
+        if (tok)
+        {
+	    strncpy(dhcpv6_data->dns.nameserver1, tok, (sizeof(dhcpv6_data->dns.nameserver1)-1));
+        }
+        dhcpv6_data->dns.assigned = true;
+    }
+    else
+    {
+        DHCPMGR_LOG_INFO("[%s-%d] DNS servers are missing\n", __FUNCTION__, __LINE__);
+    }
+
+    /** Domain Name */
+    if ((env = getenv(DHCPv6_OPTION_DOMAIN)) != NULL)
+    {
+        strncpy(dhcpv6_data->domainName, env, sizeof(dhcpv6_data->domainName));
+    }
+    else
+    {
+        DHCPMGR_LOG_INFO("[%s-%d] Domain name is missing\n", __FUNCTION__, __LINE__);
+    }
+
+    /** NTP Server */
+    if ((env = getenv(DHCPv6_OPTION_NTP)) != NULL)
+    {
+        strncpy(dhcpv6_data->ntpserver, env, sizeof(dhcpv6_data->ntpserver));
+    }
+    else
+    {
+        DHCPMGR_LOG_INFO("[%s-%d] NTP server is missing\n", __FUNCTION__, __LINE__);
+    }
+
+    /** AFTR (Access Gateway for DS-Lite) */
+    if ((env = getenv(DHCPv6_OPTION_DSLITE)) != NULL)
+    {
+        strncpy(dhcpv6_data->aftr, env, sizeof(dhcpv6_data->aftr));
+    }
+    else
+    {
+        DHCPMGR_LOG_INFO("[%s-%d] AFTR name is missing\n", __FUNCTION__, __LINE__);
+    }
+
+    /** MAP-T Configuration */
+    if ((env = getenv(DHCPv6_OPTION_MAPT)) != NULL)
+    {
+        strncpy((char *) dhcpv6_data->mapt.Container, env, sizeof(dhcpv6_data->mapt.Container));
+        dhcpv6_data->mapt.Assigned = true;
+    }
+    else
+    {
+        DHCPMGR_LOG_INFO("[%s-%d] MAP-T configuration is missing\n", __FUNCTION__, __LINE__);
+    }
+
+    return 0;
+}
+
+static  int send_dhcp6_data_to_leaseMonitor (DHCPv6_PLUGIN_MSG *dhcpv6_data)
+{
+    if ( NULL == dhcpv6_data)
+    {
+        DHCPMGR_LOG_INFO ("[%s-%d] Invalid argument\n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    /**
+     * Send data to dhcpmanager.
+     */
+    PLUGIN_MSG msg;
+    memset(&msg, 0, sizeof(PLUGIN_MSG));
+
+    strcpy(msg.ifname, dhcpv6_data->ifname);
+    msg.version = DHCP_VERSION_6;
+    memcpy(&msg.data.dhcpv6, dhcpv6_data, sizeof(DHCPv6_PLUGIN_MSG));
+
+    int sock   = -1;
+    int conn   = -1;
+    int bytes  = -1;
+    int sz_msg = sizeof(PLUGIN_MSG);
+
+    sock = nn_socket(AF_SP, NN_PUSH);
+    if (sock < 0)
+    {
+        DHCPMGR_LOG_ERROR("[%s-%d] Failed to create the socket , error = [%d][%s]\n", __FUNCTION__, __LINE__, errno, strerror(errno));
+        return -1;
+    }
+
+    DHCPMGR_LOG_INFO("[%s-%d] Created socket endpoint \n", __FUNCTION__, __LINE__);
+
+    conn = nn_connect(sock, DHCP_MANAGER_ADDR);
+    if (conn < 0)
+    {
+        DHCPMGR_LOG_ERROR("[%s-%d] Failed to connect to the dhcpmanager [%s], error= [%d][%s] \n", __FUNCTION__, __LINE__, DHCP_MANAGER_ADDR,errno, strerror(errno));
+        nn_close(sock);
+        return -1;
+    }
+
+    DHCPMGR_LOG_INFO("[%s-%d] Connected to server socket [%s] \n", __FUNCTION__, __LINE__, DHCP_MANAGER_ADDR);
+
+    for (int i = 0; i < MAX_SEND_THRESHOLD; i++)
+    {
+        bytes = nn_send(sock, (char *) &msg, sz_msg, 0);
+        if (bytes < 0)
+        {
+            sleep(1);
+            DHCPMGR_LOG_ERROR("[%s-%d] Failed to send data to the dhcpmanager error=[%d][%s] \n", __FUNCTION__, __LINE__,errno, strerror(errno));
+        }
+        else
+            break;
+    }
+
+    DHCPMGR_LOG_INFO("Successfully send %d bytes to dhcpmanager \n", bytes);
+    nn_close(sock);
+    return 0;
+}
+
+static int handle_dibbler_event(char *input_option)
+{
+    if (input_option == NULL)
+    {
+        DHCPMGR_LOG_ERROR("[%s][%d] Invalid argument error!!! \n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    DHCPMGR_LOG_INFO("[%s][%d] Received [%s] event from Dibbler \n", __FUNCTION__, __LINE__, input_option);
+
+    int ret = 0;
+    DHCPv6_PLUGIN_MSG data;
+    memset(&data, 0, sizeof(data));
+
+    ret = get_and_fill_env_data_dhcp6(&data, input_option);
+    if (ret != 0)
+    {
+        DHCPMGR_LOG_ERROR("[%s][%d] Failed to get DHCPv6 data from environment \n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    // Send DHCPv6 data to lease monitor
+    ret = send_dhcp6_data_to_leaseMonitor(&data);
+    if (ret != 0)
+    {
+        DHCPMGR_LOG_ERROR("[%s][%d] Failed to send DHCPv6 data to leaseMonitor \n", __FUNCTION__, __LINE__);
+        return -1;
+    }
+
+    return ret;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2 || !argv || !argv[1] || strlen(argv[1]) == 0)
+    {
+        DHCPMGR_LOG_ERROR ("%s:%d Invalid arguments\n", __FUNCTION__,__LINE__);
+        return -1;
+    }
+
+    DHCPMGR_LOG_INFO("Dibbler Plugin: Received event %s\n", argv[1]);
+    if (!strcmp(argv[1], "add") || !strcmp(argv[1], "del"))
+    {
+        if (handle_dibbler_event(argv[1]) != 0)
+        {
+            DHCPMGR_LOG_INFO ("%s:%d handle_event failed for %s\n",__FUNCTION__,__LINE__,argv[1]);
+        }
+    }
+
+    return 0;
+}

--- a/source/DHCPClientUtils/DHCPv6Client/dhcpv6_interface.h
+++ b/source/DHCPClientUtils/DHCPv6Client/dhcpv6_interface.h
@@ -76,6 +76,13 @@ typedef struct _DHCPv6_PLUGIN_MSG
     }mape;
     #endif
 
+    //Vendor Specific Options
+    struct {
+        bool Assigned;  /**< Have we received vendor-specific options? */
+        unsigned char Data[BUFLEN_256]; /* Buffer to store vendor-specific options */
+        uint32_t Length; /* Length of vendor-specific options */
+    }vendor;
+
     char domainName[BUFLEN_64];  /**< New domain Name,   */
     char ntpserver[BUFLEN_128];  /**< New ntp server(s), dhcp server may provide this */
     char aftr[AFTR_NAME_LENGTH];      /**< dhcp server may provide this */

--- a/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.h
+++ b/source/DHCPMgrUtils/dhcp_lease_monitor_thrd.h
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+#ifndef DHCP_LEASE_MONITOR_THRD_H
+#define DHCP_LEASE_MONITOR_THRD_H
 
 #include <stdbool.h>
 #include <nanomsg/nn.h>
@@ -49,4 +51,4 @@ typedef struct {
  */
 int  DhcpMgr_LeaseMonitor_Start();
 
-
+#endif

--- a/source/TR-181/board_sbapi/cosa_dhcpv6_apis.c
+++ b/source/TR-181/board_sbapi/cosa_dhcpv6_apis.c
@@ -138,7 +138,7 @@ ANSC_STATUS syscfg_set_string(const char* name, const char* value);
  * @param Pointer to ipc_dhcpv6_data_t holds the IPv6 configurations
  * @return 0 on success else returned -1
  */
-static int send_dhcp_data_to_wanmanager (ipc_dhcpv6_data_t *dhcpv6_data); /* Send data to wanmanager using nanomsg. */
+//static int send_dhcp_data_to_wanmanager (ipc_dhcpv6_data_t *dhcpv6_data); /* Send data to wanmanager using nanomsg. */
 #ifdef WAN_FAILOVER_SUPPORTED
 pthread_t Ipv6Handle_tid;
 void *Ipv6ModeHandler_thrd(void *data);
@@ -1143,7 +1143,7 @@ static desiredRtAdvInfo *rtAdvInfo;
 
 #define IPv6_RT_MON_NOTIFY_CMD "kill -10 `pidof ipv6rtmon`"
 #endif // RA_MONITOR_SUPPORT
-static void * dhcpv6c_dbg_thrd(void * in);
+//static void * dhcpv6c_dbg_thrd(void * in);
 
 #ifdef DHCPV6_SERVER_SUPPORT
 extern void * dhcpv6s_dbg_thrd(void * in);
@@ -1944,14 +1944,14 @@ CosaDmlDhcpv6SMsgHandler
         DHCPVS_DEBUG_PRINT
         g_dhcpv6_server_prefix_ready = TRUE;
     }
-
+#if 0
     /*we start a thread to hear dhcpv6 client message about prefix/address */
         if ( !mkfifo(CCSP_COMMON_FIFO, 0666) || errno == EEXIST )
     {
         if (pthread_create(&g_be_ctx.dbgthrdc, NULL, dhcpv6c_dbg_thrd, NULL)  || pthread_detach(g_be_ctx.dbgthrdc))
             DHCPMGR_LOG_WARNING("%s error in creating dhcpv6c_dbg_thrd\n", __FUNCTION__);
     }
-
+#endif
     /*we start a thread to hear dhcpv6 server messages */
     if ( !mkfifo(DHCPS6V_SERVER_RESTART_FIFO, 0666) || errno == EEXIST )
     {
@@ -7613,7 +7613,7 @@ int Get_Device_Mode()
     return deviceMode;
 
 }
-
+#if 0
 static int format_time(char *time)
 {
     if (time == NULL)
@@ -7623,14 +7623,14 @@ static int format_time(char *time)
     }
     return 0;
 }
-
+#endif
 /* This thread is added to handle the LnF interface IPv6 rule, because LnF is coming up late in XB6 devices.
 This thread can be generic to handle the operations depending on the interfaces. Other interface and their events can be register here later based on requirement */
 #if defined(CISCO_CONFIG_DHCPV6_PREFIX_DELEGATION) && defined(_CBR_PRODUCT_REQ_)
 #else
-static pthread_t InfEvtHandle_tid;
-static int sysevent_fd_1;
-static token_t sysevent_token_1;
+//static pthread_t InfEvtHandle_tid;
+//static int sysevent_fd_1;
+//static token_t sysevent_token_1;
 
 
 #ifdef RDKB_EXTENDER_ENABLED
@@ -7918,7 +7918,7 @@ int handle_MocaIpv6(char *status)
     return 0;
 
 }
-
+#if 0
 static void *InterfaceEventHandler_thrd(void *data)
 {
     UNREFERENCED_PARAMETER(data);
@@ -8133,6 +8133,7 @@ static void *InterfaceEventHandler_thrd(void *data)
     return NULL;
 }
 #endif
+#endif 
 
 #if defined (RDKB_EXTENDER_ENABLED) || defined (WAN_FAILOVER_SUPPORTED)
 
@@ -8361,6 +8362,7 @@ void configureLTEIpv6(char* v6addr)
 }
 #endif
 
+#if 0
 /*******************************************************
 * Function Name : isDropbearRunningWithIpv6 (char *pIpv6Addr)
 *      It will verify, dropbear process is running with provided IPv6 address or not
@@ -9684,6 +9686,7 @@ EXIT:
 #endif
     return NULL;
 }
+#endif
 
 #if 0 //TODO: cleanup dhcp 
 ANSC_STATUS CosaDmlStartDhcpv6Client(ANSC_HANDLE hInsContext)
@@ -9994,6 +9997,7 @@ EXIT:
 #endif // RA_MONITOR_SUPPORT
 
 #if defined(FEATURE_RDKB_WAN_MANAGER)
+#if 0
 static int send_dhcp_data_to_wanmanager (ipc_dhcpv6_data_t *dhcpv6_data)
 {
     int ret = ANSC_STATUS_SUCCESS;
@@ -10055,6 +10059,7 @@ static int send_dhcp_data_to_wanmanager (ipc_dhcpv6_data_t *dhcpv6_data)
     nn_close (sock);
     return ret;
 }
+#endif
 
 #if defined (WAN_FAILOVER_SUPPORTED) && !defined (RDKB_EXTENDER_ENABLED)
 void SwitchToGlobalIpv6()


### PR DESCRIPTION
Reason for change: Read the dibbler environment variables and update the lease monitor thread through C plugin rather than notify script.
Risks: None

Signed-off-by: Krithiksha Prabhakar [krithiksha.prabhakar@t-systems.com](mailto:krithiksha.prabhakar@t-systems.com)