### PR TITLE
RDKBNETWOR-56 : Ipv6 lease delete is not working

### DIFF
--- a/source/DHCPClientUtils/DHCPv6Client/dhcpmgr_dibbler_plugin/dhcpmgr_dibbler_plugin.c
+++ b/source/DHCPClientUtils/DHCPv6Client/dhcpmgr_dibbler_plugin/dhcpmgr_dibbler_plugin.c
@@ -94,7 +94,7 @@ static int get_and_fill_env_data_dhcp6(DHCPv6_PLUGIN_MSG *dhcpv6_data, char *inp
     {
         dhcpv6_data->isExpired = false;
     }
-    else if (strcmp(input_option, "del") == 0 || strcmp(input_option, "delete") == 0 || strcmp(input_option, "deleted") == 0)
+    else if (strcmp(input_option, "del") == 0 || strcmp(input_option, "delete") == 0 ||  strcmp(input_option, "expire") == 0)
     {
         dhcpv6_data->isExpired = true;
     }
@@ -353,7 +353,7 @@ int main(int argc, char *argv[])
     }
 
     DHCPMGR_LOG_INFO("Dibbler Plugin: Received event %s\n", argv[1]);
-    if (!strcmp(argv[1], "add") || !strcmp(argv[1], "del") || !strcmp(argv[1], "update") || !strcmp(argv[1], "delete") || !strcmp(argv[1], "deleted"))
+    if (!strcmp(argv[1], "add") || !strcmp(argv[1], "del") || !strcmp(argv[1], "update") || !strcmp(argv[1], "delete") || !strcmp(argv[1], "expire"))
     {
         if (handle_dibbler_event(argv[1]) != 0)
         {

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -127,7 +127,7 @@ void DhcpMgr_ProcessV6Lease(PCOSA_DML_DHCPCV6_FULL pDhcp6c)
             DHCPMGR_LOG_INFO("%s %d: lease updated for %s \n",__FUNCTION__, __LINE__, pDhcp6c->Cfg.Interface);
             leaseChanged = TRUE;
         }
-        else if(current->isExpired == TRUE && newLease->isExpired == FALSE)
+        else if(current->isExpired == FALSE && newLease->isExpired == TRUE)
         {
             DhcpMgr_PublishDhcpV6Event(pDhcp6c, DHCP_LEASE_DEL);
             DHCPMGR_LOG_INFO("%s %d: lease expired  for %s \n",__FUNCTION__, __LINE__, pDhcp6c->Cfg.Interface);


### PR DESCRIPTION
Adding fix for handling lease expire message from the DHCPv6 plugin